### PR TITLE
fix: adicionado typecast quando realiza um malloc

### DIFF
--- a/src/3-Basico/13-Ponteiros.md
+++ b/src/3-Basico/13-Ponteiros.md
@@ -83,7 +83,7 @@ int main(void) {
     int *ponteiro;  // para declarar um ponteiro, definimos o seu tipo
                     // e o nome com o asterisco atrás dele.
 
-    ponteiro = malloc(sizeof(int));
+    ponteiro = (int *)malloc(sizeof(int));
     //a função malloc armazena na memória o tamanho em bytes que você quiser.
     //a função sizeof retorna o tamanho do tipo que você quer, portanto o ponteiro fica alocado corretamente para o tamanho indicado e está pronto para uso.
 
@@ -104,7 +104,7 @@ int main(void) {
 
     int *ponteiro;
 
-    ponteiro = malloc(sizeof(int));
+    ponteiro = (int *)malloc(sizeof(int));
 
     //esse código funciona mas não é adequado
     //ao compilar o compilador dá diversos warning(avisos)


### PR DESCRIPTION
A função `malloc` retorna um `void *`. Então por boas práticas, é ideal fazer sempre um typecast para o tipo do ponteiro evitando assim `warnings` na compilação.